### PR TITLE
Feature/ingress v1 api

### DIFF
--- a/charts/simple/templates/_helpers.tpl
+++ b/charts/simple/templates/_helpers.tpl
@@ -41,3 +41,11 @@ cert-manager.io/v1
 certmanager.k8s.io/v1alpha1
 {{- end }}
 {{- end }}
+
+{{- define "ingress.api-version" }}
+{{- if semverCompare ">=1.18" .Capabilities.KubeVersion.Version }}
+networking.k8s.io/v1
+{{- else }}
+networking.k8s.io/v1beta1
+{{- end }}
+{{- end }}

--- a/charts/simple/templates/_helpers.tpl
+++ b/charts/simple/templates/_helpers.tpl
@@ -36,8 +36,8 @@ release: {{ .Release.Name }}
 
 {{- define "cert-manager.api-version" }}
 {{- if ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
-apiVersion: cert-manager.io/v1
+cert-manager.io/v1
 {{- else }}
-apiVersion: certmanager.k8s.io/v1alpha1
+certmanager.k8s.io/v1alpha1
 {{- end }}
 {{- end }}

--- a/charts/simple/templates/certificate.yaml
+++ b/charts/simple/templates/certificate.yaml
@@ -2,7 +2,7 @@
 {{- $context_ssl := .Values.ssl }}
 {{- if $context_ingress.tls }}
 {{- if has $context_ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
-{{- include "cert-manager.api-version" . }}
+apiVersion: {{ include "cert-manager.api-version" . | trim }}
 kind: Certificate
 metadata:
   name: {{ .Release.Name }}-crt
@@ -18,7 +18,7 @@ spec:
   issuerRef:
     name: {{ $context_ssl.issuer }}
     kind: ClusterIssuer
-{{- if not ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+{{- if eq ( include "cert-manager.api-version" . | trim ) "certmanager.k8s.io/v1alpha1" }}
   acme:
     config:
       - http01:
@@ -29,7 +29,7 @@ spec:
 ---
 
 {{- else if eq $context_ssl.issuer "selfsigned" }}
-{{- include "cert-manager.api-version" . }}
+apiVersion: {{ include "cert-manager.api-version" . | trim }}
 kind: Certificate
 metadata:
   name: {{ .Release.Name }}-crt
@@ -69,7 +69,7 @@ data:
 {{- if $domain.ssl }}
 {{- if $domain.ssl.enabled }}
 {{- if has $domain.ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
-{{- include "cert-manager.api-version" $ }}
+apiVersion: {{ include "cert-manager.api-version" $ | trim }}
 kind: Certificate
 metadata:
   name: {{ $.Release.Name }}-crt-{{ $index }}
@@ -85,7 +85,7 @@ spec:
   issuerRef:
     name: {{ $domain.ssl.issuer }}
     kind: ClusterIssuer
-{{- if not ( $.Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+{{- if eq ( include "cert-manager.api-version" $ | trim ) "certmanager.k8s.io/v1alpha1" }}
   acme:
     config:
       - http01:
@@ -96,7 +96,7 @@ spec:
 ---
 
 {{- else if eq $domain.ssl.issuer "selfsigned" }}
-{{- include "cert-manager.api-version" $ }}
+apiVersion: {{ include "cert-manager.api-version" $ | trim }}
 kind: Certificate
 metadata:
   name: {{ $.Release.Name }}-crt-{{ $index }}

--- a/charts/simple/templates/ingress.yaml
+++ b/charts/simple/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- $ingress := .Values.ingress.default }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ include "ingress.api-version" . | trim }}
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-simple
@@ -53,8 +53,15 @@ spec:
       paths:
       - path: /
         backend:
+          {{- if eq ( include "ingress.api-version" . | trim ) "networking.k8s.io/v1" }}
+          service:
+            name: {{ .Release.Name }}-simple
+            port: 
+              number: 80
+          {{- else }}
           serviceName: {{ .Release.Name }}-simple
           servicePort: 80
+          {{- end }}
 ---
 # Ingresses for exposeDomains 
 {{- range $ingress_index, $ingress := $.Values.ingress }}
@@ -71,7 +78,7 @@ spec:
 {{- end }}
 
 {{- if $ingress_in_use }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ include "ingress.api-version" $ | trim }}
 kind: Ingress
 metadata:
   name: {{ $.Release.Name }}-simple-{{ $ingress_index }}
@@ -137,8 +144,15 @@ spec:
       paths:
       - path: {{ if eq $ingress.type "gce" }}/*{{ else }}/{{ end }}
         backend:
+          {{- if eq ( include "ingress.api-version" $ | trim ) "networking.k8s.io/v1" }}
+          service:
+            name: {{ $.Release.Name }}-simple
+            port: 
+              number: 80
+          {{- else }}
           serviceName: {{ $.Release.Name }}-simple
           servicePort: 80
+          {{- end }}
   {{- end }}
   {{- end }}
 ---

--- a/charts/simple/templates/ingress.yaml
+++ b/charts/simple/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: {{ $ingress.type | quote }}
     {{- if $ingress.tls }}
-    {{- if ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+    {{- if eq ( include "cert-manager.api-version" . | trim ) "cert-manager.io/v1" }}
     acme.cert-manager.io/http01-edit-in-place: "true"
     {{- else }}
     certmanager.k8s.io/acme-http01-edit-in-place: "true"
@@ -78,7 +78,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: {{ $ingress.type | quote }}
     {{- if $ingress.tls }}
-    {{- if ( $.Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+    {{- if eq ( include "cert-manager.api-version" $ | trim ) "cert-manager.io/v1" }}
     acme.cert-manager.io/http01-edit-in-place: "true"
     {{- else }}
     certmanager.k8s.io/acme-http01-edit-in-place: "true"

--- a/charts/simple/tests/ingress_test.yaml
+++ b/charts/simple/tests/ingress_test.yaml
@@ -32,11 +32,49 @@ tests:
           path: spec.rules[0].host
           value: 'foo.namespace.baz'
 
-  - it: directs traefik requests to simple service by default
+  - it: directs traefik requests to simple service by default (cm 0.8)
+    template: ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 17
+      apiVersions:
+        - certmanager.k8s.io/v1alpha1
     asserts:
       - equal:
           path: spec.rules[0].http.paths[0].backend.serviceName
           value: 'RELEASE-NAME-simple'
+
+  - it: directs traefik requests to simple service by default (cm 1.4+)
+    template: ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 18
+      apiVersions:
+        - cert-manager.io/v1
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: 'RELEASE-NAME-simple'
+  
+  - it: uses correct ingress api version (1.17)
+    template: ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 17
+    asserts:
+      - equal:
+          path: apiVersion
+          value: 'networking.k8s.io/v1beta1'
+
+  - it: uses correct ingress api version (1.18+)
+    template: ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 18
+    asserts:
+      - equal:
+          path: apiVersion
+          value: 'networking.k8s.io/v1'
 
   - it: shortens long project names
     set:


### PR DESCRIPTION
- Unifies certificate apiVersion conditionals 
- Uses Ingress API v1 when kubernetes version is above 1.18
- Adjusted chart unittests