### PR TITLE
Allow security header customization

### DIFF
--- a/charts/simple/templates/configmap.yaml
+++ b/charts/simple/templates/configmap.yaml
@@ -74,15 +74,14 @@ data:
         gzip_disable                msie6;                                                                                                                 
                                                                                                                                                           
         ## https://www.owasp.org/index.php/List_of_useful_HTTP_headers.
-        add_header                  X-Frame-Options SAMEORIGIN;                                                                                            
-        add_header                  X-Content-Type-Options nosniff;
+        {{- range $header, $value := .Values.nginx.security_headers }}
+        add_header                  {{ $header }} {{ $value }};
+        {{- end }}
         add_header                  Strict-Transport-Security "max-age=31536000; {{ .Values.nginx.hsts_include_subdomains }} preload" always;
-        add_header                  X-XSS-Protection '1; mode=block';
         {{- if .Values.nginx.content_security_policy }}
         add_header                  Content-Security-Policy "{{ .Values.nginx.content_security_policy }}" always;
         {{- end }}
-        add_header                  Referrer-Policy "no-referrer, strict-origin-when-cross-origin" always;
-
+        
         map_hash_bucket_size        128;
 
         map $http_host $x_robots_tag_header {

--- a/charts/simple/tests/configmap_test.yaml
+++ b/charts/simple/tests/configmap_test.yaml
@@ -42,3 +42,39 @@ tests:
       matchRegex:
         path: data.simple_conf
         pattern: 'auth_basic "Restricted";'
+
+  - it: tests nginx security headers
+    template: configmap.yaml
+    set:
+      nginx:
+        security_headers: 
+          foo: bar
+        content_security_policy: "baz"
+    asserts:
+    - matchRegex:
+        path: data.nginx_conf
+        pattern: 'add_header                  X-XSS-Protection "1; mode=block";'
+    - matchRegex:
+        path: data.nginx_conf
+        pattern: 'add_header                  foo bar;'
+    - matchRegex:
+        path: data.nginx_conf
+        pattern: 'add_header                  Content-Security-Policy "baz" always;'
+
+  - it: tests ability to set empty nginx security headers
+    template: configmap.yaml
+    set:
+      nginx:
+        security_headers: []
+        content_security_policy: ""
+    asserts:
+    - notMatchRegex:
+        path: data.nginx_conf
+        pattern: 'add_header                  X-XSS-Protection "1; mode=block";'
+    - notMatchRegex:
+        path: data.nginx_conf
+        pattern: 'add_header                  header_foo value_bar;'
+    - notMatchRegex:
+        path: data.nginx_conf
+        pattern: 'add_header                  Content-Security-Policy "baz" always;'
+

--- a/charts/simple/values.yaml
+++ b/charts/simple/values.yaml
@@ -149,6 +149,12 @@ nginx:
   real_ip_header: X-Forwarded-For
 
   # Security headers
+  security_headers:
+    X-Frame-Options: 'SAMEORIGIN'
+    X-Content-Type-Options: 'nosniff'
+    X-XSS-Protection: '"1; mode=block"'
+    Referrer-Policy: '"no-referrer, strict-origin-when-cross-origin" always'
+
   # includeSubdomains should be used whenever possible, but before enabling it needs to be made sure there are no subdomains not using https:
   hsts_include_subdomains: ""
   #hsts_include_subdomains: " includeSubDomains;"


### PR DESCRIPTION
tip: remove security headers by setting `nginx.security_headers: ""`
