### PR TITLE
Silta container base image migration to Docker Hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   node16:
     docker:
-      - image: eu.gcr.io/silta-images/cicd:circleci-php8.0-node16-composer2-v0.1
+      - image: wunderio/silta-cicd:circleci-php8.0-node16-composer2-v0.1
 
 jobs:
   site-test:

--- a/silta/nginx.Dockerfile
+++ b/silta/nginx.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for building nginx.
 #Comment to trigger rebuild
-FROM wunderio/drupal-nginx:v0.1
+FROM wunderio/silta-nginx:v0.1
 
 COPY . /app/web


### PR DESCRIPTION
Silta docker container images are being migrated to Docker Hub. 
This PR changes base image location to the new image registry.

Please review adjusted image paths and make sure this PR only changes relevant configuration files.

This pull request was created with https://github.com/wunderio/internal-mass-updater.