### PR TITLE
SLT-779: Single subdomain

### DIFF
--- a/charts/simple/templates/_helpers.tpl
+++ b/charts/simple/templates/_helpers.tpl
@@ -3,6 +3,14 @@ app: {{ .Values.app | quote }}
 release: {{ .Release.Name }}
 {{- end }}
 
+{{- define "simple.domainSeperator" -}}
+{{- if .Values.singleSubdomain -}}
+-
+{{- else -}}
+.
+{{- end -}}
+{{- end -}}
+
 {{- define "simple.domain" -}}
 {{- $projectName := regexReplaceAll "[^[:alnum:]]" (.Values.projectName | default .Release.Namespace) "-"  | trimSuffix "-" | lower }}
 {{- $projectNameHash := sha256sum $projectName | trunc 3 }}
@@ -13,7 +21,7 @@ release: {{ .Release.Name }}
 {{- $maxEnvironmentNameLength := int (sub 62 (add (len .Values.clusterDomain) (len $projectName))) }}
 {{- $environmentName := (ge (len $environmentName) $maxEnvironmentNameLength) | ternary (print ($environmentName | trunc (int (sub $maxEnvironmentNameLength 3))) $environmentNameHash) $environmentName -}}
 
-{{ $environmentName }}.{{ $projectName }}.{{ .Values.clusterDomain }}
+{{ $environmentName }}{{ include "simple.domainSeperator" . }}{{ $projectName }}.{{ .Values.clusterDomain }}
 {{- end -}} 
 
 {{- define "simple.referenceEnvironment" -}}

--- a/charts/simple/values.schema.json
+++ b/charts/simple/values.schema.json
@@ -12,6 +12,7 @@
     "app": { "type": "string" },
     "exposeDomains": { "type": "object", "items": { "type": "object"}},
     "exposeDomainsDefaults": { "type": "object"},
+    "singleSubdomain": { "type": "boolean"},
     "ssl": { "type": "object" },
     "backendConfig": { "type": ["array","object"], "items": { "type": "object"}},
     "ingress": { "type": "object" },

--- a/charts/simple/values.yaml
+++ b/charts/simple/values.yaml
@@ -60,6 +60,10 @@ exposeDomains: {}
 exposeDomainsDefaults:
   ingress: default
 
+# Domains by default are created following pattern branch.repository.cluster
+# By enabling single subdomain it will be converted to branch-repository.cluster
+singleSubdomain: false
+
 # Settings for default site provided by this deployment
 ssl:
   # Enable HTTPS for this deployment


### PR DESCRIPTION
**Allows setting single subdomain.**

Features:
- Adds "singleSubdomain" flag to set "-" as a prefix, branch and repo separator.
- Set flag to "false" by default to not break any existing implementations