### PR TITLE
nginx.basicauth.realipfrom and nginx.basicauth.noauthips depreciation

### DIFF
--- a/charts/simple/templates/_helpers.tpl
+++ b/charts/simple/templates/_helpers.tpl
@@ -32,11 +32,6 @@ release: {{ .Release.Name }}
   {{- if .Values.nginx.basicauth.enabled }}
   satisfy any;
   allow 127.0.0.1;
-  {{- if .Values.nginx.basicauth.noauthips }}
-  {{- range .Values.nginx.basicauth.noauthips }}
-  allow {{ . }};
-  {{- end }}
-  {{- end }}
   {{- if .Values.nginx.noauthips }}
   {{- range .Values.nginx.noauthips }}
   allow {{ . }};

--- a/charts/simple/templates/checks.yaml
+++ b/charts/simple/templates/checks.yaml
@@ -1,0 +1,6 @@
+{{ if .Values.nginx.basicauth.realipfrom }}
+{{- fail "nginx.basicauth.realipfrom configuration schema is depreciated migrate configuration to nginx.realipfrom" -}}
+{{- end }}
+{{ if .Values.nginx.basicauth.noauthips }}
+{{- fail "nginx.basicauth.noauthips configuration schema is depreciated migrate configuration to nginx.noauthips" -}}
+{{- end }}

--- a/charts/simple/templates/configmap.yaml
+++ b/charts/simple/templates/configmap.yaml
@@ -29,11 +29,6 @@ data:
         {{- end }}
         {{- end }}
 
-        {{ if .Values.nginx.basicauth.realipfrom }}
-        # This will be depreciated, migrate this setting to nginx.realipfrom
-        set_real_ip_from            {{ .Values.nginx.basicauth.realipfrom }};
-        {{- end }}
-
         real_ip_header              {{ .Values.nginx.real_ip_header }};
 
         include                     /etc/nginx/mime.types;                                 

--- a/charts/simple/tests/configmap_test.yaml
+++ b/charts/simple/tests/configmap_test.yaml
@@ -28,7 +28,7 @@ tests:
         loglevel: 'debug'
         basicauth:
           enabled: true
-          realipfrom: '1.2.3.4'
+        realipfrom: '1.2.3.4'
     asserts:
     - template: configmap.yaml
       matchRegex:

--- a/charts/simple/values.schema.json
+++ b/charts/simple/values.schema.json
@@ -36,14 +36,6 @@
                 "username": { "type": "string"},
                 "password": { "type": "string"}
               }
-            },
-            "realipfrom": {
-              "type": ["string"],
-              "deprecated": true
-            },
-            "noauthips": {
-              "type": ["object"],
-              "deprecated": true
             }
           },
           "additionalProperties": false

--- a/charts/simple/values.yaml
+++ b/charts/simple/values.yaml
@@ -129,15 +129,6 @@ nginx:
     credentials:
       username: silta
       password: demo
-
-    # Trust X-Forwarded-For from these hosts for getting external IP 
-    # This will be deprecated soon in favor of nginx.realipfrom 
-    # realipfrom: 10.0.0.0/8
-
-    # Add IP addresses that should be excluded from basicauth
-    # This will be deprecated soon in favor of nginx.noauthips 
-    # noauthips:
-    #   gke-internal: 10.0.0.0/8
   
   # Trust X-Forwarded-For from these hosts for getting external IP
   realipfrom: 


### PR DESCRIPTION
`nginx.basicauth.realipfrom` and `nginx.basicauth.noauthips` depreciation in favor of `nginx.realipfrom` and `nginx.noauthips` to conform with other charts.
Prints error message during deployment when old configuration is still defined.