### PR TITLE
Do not add backendConfig annotation to service when it's unset

### DIFF
--- a/charts/simple/templates/service.yaml
+++ b/charts/simple/templates/service.yaml
@@ -7,8 +7,8 @@ metadata:
   annotations:
     auto-downscale/down: "false"
     {{- if .Values.cluster }}
-    {{- if eq .Values.cluster.type "gke" }}
-    cloud.google.com/backend-config: '{"ports": {"8080":"{{ .Release.Name }}-simple"}}'
+    {{- if and (eq .Values.cluster.type "gke") (.Values.backendConfig) }}
+    cloud.google.com/backend-config: '{"default":"{{ .Release.Name }}-simple"}'
     {{- end }}
     {{- if .Values.cluster.vpcNative }}
     cloud.google.com/neg: '{"ingress": true}'
@@ -18,7 +18,9 @@ spec:
   type: NodePort
   externalTrafficPolicy: Local
   ports:
-    - port: 80
+    - name: web
+      protocol: TCP
+      port: 80
       targetPort: 8080
   selector:
     {{ include "simple.release_labels" . | indent 4 }}


### PR DESCRIPTION
- Does not add backendConfig annotation to service when backendConfig is unset
- Changes backendconfig rule from specific port to default

