### PR TITLE
SLT-802: Nginx: Logging: Access: Format: JSONify

### DIFF
--- a/charts/simple/templates/configmap.yaml
+++ b/charts/simple/templates/configmap.yaml
@@ -34,13 +34,46 @@ data:
         include                     /etc/nginx/mime.types;                                 
         default_type                application/octet-stream;                              
                                                                                           
-        log_format  main            '$remote_addr - $remote_user [$time_local] "$request" '
-                                    '$status $body_bytes_sent "$http_referer" '
-                                    '"$http_user_agent" "$http_x_forwarded_for"';
-                                                            
-                                                                                                              
+        log_format main             escape=json '{'
+        
+                                      # time
+                                      '"time_iso8601":"$time_iso8601"'
+                                      ',"time_ms":"$msec"'
+                                      ',"time_local":"$time_local"'
+
+                                      # duration
+                                      ',"duration_request_ms":"$request_time"'
+                                      ',"duration_upstream_s":"$upstream_response_time"'
+
+                                      # bytes
+                                      ',"response_body_b":"$body_bytes_sent"'
+                                      ',"response_b":"$bytes_sent"'
+                                      ',"request_b":"$request_length"'
+
+                                      # ip/host
+                                      ',"http_host":"$http_host"'
+                                      ',"remote_addr":"$remote_addr"'
+                                      ',"forwarded_for":"$http_x_forwarded_for"'
+                                      ',"real_ip":"$realip_remote_addr"'
+
+                                      # request
+                                      ',"request":"$request"'
+                                      ',"request_method":"$request_method"'
+                                      ',"request_uri":"$request_uri"'
+                                      ',"request_origin":"$http_origin"'
+
+                                      # response
+                                      ',"status":"$status"'
+
+                                      # browser
+                                      ',"referer":"$http_referer"'
+                                      ',"agent":"$http_user_agent"'
+                                      ',"basic_auth_user":"$remote_user"'
+
+                                    '}';          
+
         access_log                  /proc/self/fd/1 main;
-                                              
+
         send_timeout                60s;       
         sendfile                    on;        
         client_body_timeout         60s;       

--- a/charts/simple/templates/configmap.yaml
+++ b/charts/simple/templates/configmap.yaml
@@ -6,17 +6,17 @@ metadata:
     {{ include "simple.release_labels" . | indent 4 }}
 data:
   nginx_conf: |
-    # user                            nginx;                                                 
+    # user                            nginx;
     worker_processes                auto;
     worker_rlimit_nofile            10240;
 
-    error_log                       /proc/self/fd/2 {{ .Values.nginx.loglevel }};                                 
-                                                                                          
-    events {                                                                               
-        worker_connections          10240;                                                  
-        multi_accept                on;                                                    
-    }                                                                                      
-                                                                                          
+    error_log                       /proc/self/fd/2 {{ .Values.nginx.loglevel }};
+
+    events {
+        worker_connections          10240;
+        multi_accept                on;
+    }
+
     http {
 
         # List of upstream proxies we trust to set X-Forwarded-For correctly.
@@ -31,11 +31,12 @@ data:
 
         real_ip_header              {{ .Values.nginx.real_ip_header }};
 
-        include                     /etc/nginx/mime.types;                                 
-        default_type                application/octet-stream;                              
-                                                                                          
+        include                     /etc/nginx/mime.types;
+        default_type                application/octet-stream;
+
+        {{ if eq $.Values.logging.format "json" }}
         log_format main             escape=json '{'
-        
+
                                       # time
                                       '"time_iso8601":"$time_iso8601"'
                                       ',"time_ms":"$msec"'
@@ -70,37 +71,43 @@ data:
                                       ',"agent":"$http_user_agent"'
                                       ',"basic_auth_user":"$remote_user"'
 
-                                    '}';          
+                                    '}';
+        {{ end }}
+        {{ if eq $.Values.logging.format "default" }}
+        log_format  main            '$remote_addr - $remote_user [$time_local] "$request" '
+                                    '$status $body_bytes_sent "$http_referer" '
+                                    '"$http_user_agent" "$http_x_forwarded_for"';
+        {{ end }}
 
         access_log                  /proc/self/fd/1 main;
 
-        send_timeout                60s;       
-        sendfile                    on;        
-        client_body_timeout         60s;       
-        client_header_timeout       60s;                                                                                                                   
-        client_max_body_size        32m;                                                                                                                   
-        client_body_buffer_size     16k;                                                                                                                   
-        client_header_buffer_size   4k;                                                                                                                    
-        large_client_header_buffers 8 16K;                                                                                                                 
-        keepalive_timeout           75s;                                                                                                                   
-        keepalive_requests          100;                                                                                                                   
-        reset_timedout_connection   off;                                                                                                                   
-        tcp_nodelay                 on;                                                                                                                    
-        tcp_nopush                  on;                                                                                                                    
-        server_tokens               off;                                                                                                                   
-                                                                                                                                                          
-        ## upload_progress             uploads 1m;          
-                                              
-        gzip                        on;                      
-        gzip_buffers                16 8k;     
-        gzip_comp_level             1;         
-        gzip_http_version           1.1;       
-        gzip_min_length             20;        
+        send_timeout                60s;
+        sendfile                    on;
+        client_body_timeout         60s;
+        client_header_timeout       60s;
+        client_max_body_size        32m;
+        client_body_buffer_size     16k;
+        client_header_buffer_size   4k;
+        large_client_header_buffers 8 16K;
+        keepalive_timeout           75s;
+        keepalive_requests          100;
+        reset_timedout_connection   off;
+        tcp_nodelay                 on;
+        tcp_nopush                  on;
+        server_tokens               off;
+
+        ## upload_progress             uploads 1m;
+
+        gzip                        on;
+        gzip_buffers                16 8k;
+        gzip_comp_level             1;
+        gzip_http_version           1.1;
+        gzip_min_length             20;
         gzip_types                  text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascrip
-        gzip_vary                   on;                                                                                                                    
-        gzip_proxied                any;       
-        gzip_disable                msie6;                                                                                                                 
-                                                                                                                                                          
+        gzip_vary                   on;
+        gzip_proxied                any;
+        gzip_disable                msie6;
+
         ## https://www.owasp.org/index.php/List_of_useful_HTTP_headers.
         {{- range $header, $value := .Values.nginx.security_headers }}
         {{- if $value }}
@@ -111,7 +118,7 @@ data:
         {{- if .Values.nginx.content_security_policy }}
         add_header                  Content-Security-Policy "{{ .Values.nginx.content_security_policy }}" always;
         {{- end }}
-        
+
         map_hash_bucket_size        128;
 
         map $http_host $x_robots_tag_header {
@@ -120,22 +127,22 @@ data:
         }
         add_header                  X-Robots-Tag $x_robots_tag_header;
 
-        map $uri $no_slash_uri {                                                                                                                           
-            ~^/(?<no_slash>.*)$ $no_slash;                                                                                                                 
+        map $uri $no_slash_uri {
+            ~^/(?<no_slash>.*)$ $no_slash;
         }
 
         # List health checks that need to return status 200 here
         map $http_user_agent $hc_ua { default 0; 'GoogleHC/1.0' 1; 'kube-probe' 1; }
-                                                                                                                                                     
-        include conf.d/*.conf;                                                                                                                             
-    }     
 
-  simple_conf: |                          
-    map $http_x_forwarded_proto $fastcgi_https {                                                        
-        default $https;                                            
-        http '';                          
-        https on;                          
-    }                                      
+        include conf.d/*.conf;
+    }
+
+  simple_conf: |
+    map $http_x_forwarded_proto $fastcgi_https {
+        default $https;
+        http '';
+        https on;
+    }
 
     {{- if .Values.nginx.redirects }}
     # Custom redirects with full url matching
@@ -156,12 +163,12 @@ data:
     }
     {{- end }}
 
-                                 
-    server {                               
-        server_name simple;                          
-        listen 8080;          
 
-        # Loadbalancer health checks need to be fed with http 200 
+    server {
+        server_name simple;
+        listen 8080;
+
+        # Loadbalancer health checks need to be fed with http 200
         if ($hc_ua) { return 200; }
 
         {{- if .Values.nginx.redirects }}
@@ -174,10 +181,10 @@ data:
         }
         {{- end }}
 
-        root /var/www/html/web;                                     
+        root /var/www/html/web;
         index index.html;
         port_in_redirect off;
-                                                                              
+
         include fastcgi.conf;
 
         # Custom configuration gets included here
@@ -208,7 +215,7 @@ data:
             ## Rather than just denying .ht* in the config, why not deny
             ## access to all .invisible files
             location ~ /\. { return 404; access_log off; log_not_found off; }
-        }                                                                                                                                                                                                                                                                                                                                     
+        }
     }
 
 {{- if .Values.nginx.extraConfig }}

--- a/charts/simple/values.schema.json
+++ b/charts/simple/values.schema.json
@@ -22,7 +22,7 @@
         "vpcNative": { "type": "boolean"}
       }
     },
-    "nginx": { 
+    "nginx": {
       "type": "object",
       "properties": {
         "image": { "type": "string"},
@@ -52,6 +52,12 @@
     },
     "silta-release": {
       "type": "object"
+    },
+    "logging": {
+      "type": "object",
+      "properties": {
+        "format": { "type": "string" }
+      }
     }
   }
 }

--- a/charts/simple/values.yaml
+++ b/charts/simple/values.yaml
@@ -53,7 +53,7 @@ autoscaling:
 #     hostname: www.example.com
 #   example_no_https:
 #    hostname: insecure.example.com
-#      ssl: 
+#      ssl:
 #        enabled: false
 exposeDomains: {}
 
@@ -118,8 +118,8 @@ nginx:
       cpu: 1m
       memory: 5M
 
-  loglevel: error 
-  
+  loglevel: error
+
   # Set of values to enable and use http basic authentication
   # It is implemented only for very basic protection (like web crawlers)
   basicauth:
@@ -129,9 +129,9 @@ nginx:
     credentials:
       username: silta
       password: demo
-  
+
   # Trust X-Forwarded-For from these hosts for getting external IP
-  realipfrom: 
+  realipfrom:
     gke-internal: 10.0.0.0/8
     gce-health-check-1: 130.211.0.0/22
     gce-health-check-2: 35.191.0.0/16
@@ -156,7 +156,7 @@ nginx:
   #content_security_policy: "upgrade-insecure-requests; default-src https: data: 'unsafe-inline' 'unsafe-eval'; frame-ancestors 'self'; base-uri 'self'; object-src 'self'; connect-src wss: https:"
 
 
-  # Extra configuration block in server context. 
+  # Extra configuration block in server context.
   serverExtraConfig: |
 
   # Extra configuration block in location context.
@@ -164,3 +164,13 @@ nginx:
 
   # Extra configuration to pass to nginx as a file
   extraConfig: |
+
+logging:
+  # Currently supported formats are:
+  # - "default"
+  # - "json"
+  # It affecs the output of:
+  # - cron
+  # - nginx-access
+  # - php-fpm-access
+  format: default

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -3,6 +3,3 @@
 #
 # See https://github.com/wunderio/charts/blob/master/simple/values.yaml
 # for all possible options.
-
-logging:
-  format: json

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -3,3 +3,6 @@
 #
 # See https://github.com/wunderio/charts/blob/master/simple/values.yaml
 # for all possible options.
+
+logging:
+  format: json


### PR DESCRIPTION
See the description in [SLT-802](https://wunder.atlassian.net/browse/SLT-802).

Problem: Nginx logs are in a native format which is not very good for automated processing.
Solution: Convert the logs into JSON.

The JSON log can be turned on by the following settings:

```yml
logging:
  format: json
```

[SLT-802]: https://wunder.atlassian.net/browse/SLT-802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ