### PR TITLE
Fastly Signal Sciences WAF support

### DIFF
--- a/charts/simple/templates/configmap.yaml
+++ b/charts/simple/templates/configmap.yaml
@@ -12,6 +12,9 @@ data:
   {{- end }}
 
   nginx_conf: |
+
+    include modules/*.conf;
+
     # user                            nginx;
     worker_processes                auto;
     worker_rlimit_nofile            10240;

--- a/charts/simple/templates/configmap.yaml
+++ b/charts/simple/templates/configmap.yaml
@@ -5,19 +5,30 @@ metadata:
   labels:
     {{ include "simple.release_labels" . | indent 4 }}
 data:
+  {{- if .Values.signalsciences.enabled }}
+  nginx_signalsciences_conf: |
+    load_module /etc/nginx/modules/ngx_http_sigsci_module.so;
+    load_module /etc/nginx/modules/ndk_http_module.so;
+  {{- end }}
+
   nginx_conf: |
-    # user                            nginx;                                                 
+    # user                            nginx;
     worker_processes                auto;
     worker_rlimit_nofile            10240;
 
-    error_log                       /proc/self/fd/2 {{ .Values.nginx.loglevel }};                                 
-                                                                                          
-    events {                                                                               
-        worker_connections          10240;                                                  
-        multi_accept                on;                                                    
-    }                                                                                      
-                                                                                          
+    error_log                       /proc/self/fd/2 {{ .Values.nginx.loglevel }};
+
+    events {
+        worker_connections          10240;
+        multi_accept                on;
+    }
+
     http {
+
+        {{- if .Values.signalsciences.enabled }}
+        # Signal sciences agent socket
+        sigsci_agent_host unix:/sigsci/tmp/sigsci.sock;
+        {{- end }}
 
         # List of upstream proxies we trust to set X-Forwarded-For correctly.
         {{- if kindIs "string" .Values.nginx.realipfrom }}
@@ -31,43 +42,43 @@ data:
 
         real_ip_header              {{ .Values.nginx.real_ip_header }};
 
-        include                     /etc/nginx/mime.types;                                 
-        default_type                application/octet-stream;                              
-                                                                                          
+        include                     /etc/nginx/mime.types;
+        default_type                application/octet-stream;
+
         log_format  main            '$remote_addr - $remote_user [$time_local] "$request" '
                                     '$status $body_bytes_sent "$http_referer" '
                                     '"$http_user_agent" "$http_x_forwarded_for"';
-                                                            
-                                                                                                              
+
+
         access_log                  /proc/self/fd/1 main;
-                                              
-        send_timeout                60s;       
-        sendfile                    on;        
-        client_body_timeout         60s;       
-        client_header_timeout       60s;                                                                                                                   
-        client_max_body_size        32m;                                                                                                                   
-        client_body_buffer_size     16k;                                                                                                                   
-        client_header_buffer_size   4k;                                                                                                                    
-        large_client_header_buffers 8 16K;                                                                                                                 
-        keepalive_timeout           75s;                                                                                                                   
-        keepalive_requests          100;                                                                                                                   
-        reset_timedout_connection   off;                                                                                                                   
-        tcp_nodelay                 on;                                                                                                                    
-        tcp_nopush                  on;                                                                                                                    
-        server_tokens               off;                                                                                                                   
-                                                                                                                                                          
-        ## upload_progress             uploads 1m;          
-                                              
-        gzip                        on;                      
-        gzip_buffers                16 8k;     
-        gzip_comp_level             1;         
-        gzip_http_version           1.1;       
-        gzip_min_length             20;        
+
+        send_timeout                60s;
+        sendfile                    on;
+        client_body_timeout         60s;
+        client_header_timeout       60s;
+        client_max_body_size        32m;
+        client_body_buffer_size     16k;
+        client_header_buffer_size   4k;
+        large_client_header_buffers 8 16K;
+        keepalive_timeout           75s;
+        keepalive_requests          100;
+        reset_timedout_connection   off;
+        tcp_nodelay                 on;
+        tcp_nopush                  on;
+        server_tokens               off;
+
+        ## upload_progress             uploads 1m;
+
+        gzip                        on;
+        gzip_buffers                16 8k;
+        gzip_comp_level             1;
+        gzip_http_version           1.1;
+        gzip_min_length             20;
         gzip_types                  text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascrip
-        gzip_vary                   on;                                                                                                                    
-        gzip_proxied                any;       
-        gzip_disable                msie6;                                                                                                                 
-                                                                                                                                                          
+        gzip_vary                   on;
+        gzip_proxied                any;
+        gzip_disable                msie6;
+
         ## https://www.owasp.org/index.php/List_of_useful_HTTP_headers.
         {{- range $header, $value := .Values.nginx.security_headers }}
         {{- if $value }}
@@ -78,7 +89,7 @@ data:
         {{- if .Values.nginx.content_security_policy }}
         add_header                  Content-Security-Policy "{{ .Values.nginx.content_security_policy }}" always;
         {{- end }}
-        
+
         map_hash_bucket_size        128;
 
         map $http_host $x_robots_tag_header {
@@ -87,22 +98,22 @@ data:
         }
         add_header                  X-Robots-Tag $x_robots_tag_header;
 
-        map $uri $no_slash_uri {                                                                                                                           
-            ~^/(?<no_slash>.*)$ $no_slash;                                                                                                                 
+        map $uri $no_slash_uri {
+            ~^/(?<no_slash>.*)$ $no_slash;
         }
 
         # List health checks that need to return status 200 here
         map $http_user_agent $hc_ua { default 0; 'GoogleHC/1.0' 1; 'kube-probe' 1; }
-                                                                                                                                                     
-        include conf.d/*.conf;                                                                                                                             
-    }     
 
-  simple_conf: |                          
-    map $http_x_forwarded_proto $fastcgi_https {                                                        
-        default $https;                                            
-        http '';                          
-        https on;                          
-    }                                      
+        include conf.d/*.conf;
+    }
+
+  simple_conf: |
+    map $http_x_forwarded_proto $fastcgi_https {
+        default $https;
+        http '';
+        https on;
+    }
 
     {{- if .Values.nginx.redirects }}
     # Custom redirects with full url matching
@@ -123,12 +134,12 @@ data:
     }
     {{- end }}
 
-                                 
-    server {                               
-        server_name simple;                          
-        listen 8080;          
 
-        # Loadbalancer health checks need to be fed with http 200 
+    server {
+        server_name simple;
+        listen 8080;
+
+        # Loadbalancer health checks need to be fed with http 200
         if ($hc_ua) { return 200; }
 
         {{- if .Values.nginx.redirects }}
@@ -141,10 +152,10 @@ data:
         }
         {{- end }}
 
-        root /var/www/html/web;                                     
+        root /var/www/html/web;
         index index.html;
         port_in_redirect off;
-                                                                              
+
         include fastcgi.conf;
 
         # Custom configuration gets included here
@@ -175,7 +186,7 @@ data:
             ## Rather than just denying .ht* in the config, why not deny
             ## access to all .invisible files
             location ~ /\. { return 404; access_log off; log_not_found off; }
-        }                                                                                                                                                                                                                                                                                                                                     
+        }
     }
 
 {{- if .Values.nginx.extraConfig }}

--- a/charts/simple/templates/deployment.yaml
+++ b/charts/simple/templates/deployment.yaml
@@ -35,6 +35,14 @@ spec:
           mountPath: /etc/nginx/conf.d/simple.conf # mount nginx-conf configmap volume to /etc/nginx
           readOnly: true
           subPath: simple_conf
+        {{- if .Values.signalsciences.enabled }}
+        - name: nginx-conf
+          mountPath: /etc/nginx/modules/nginx_signalsciences.conf
+          readOnly: true
+          subPath: nginx_signalsciences_conf
+        - name: sigsci-tmp
+          mountPath: /sigsci/tmp
+        {{- end }}
         {{- if .Values.nginx.extraConfig }}
         - name: nginx-conf
           # provide empty configuration file in /etc/nginx/conf.d for users to populate
@@ -65,6 +73,35 @@ spec:
         resources:
 {{ .Values.nginx.resources | toYaml | indent 10 }}
 
+      {{- if .Values.signalsciences.enabled }}
+      # Signal Services container
+      - name: sigsci
+        image: {{ .Values.signalsciences.image }}:{{ .Values.signalsciences.imageTag }}
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: SIGSCI_ACCESSKEYID
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Release.Name }}-secrets-simple
+                key: signalsciences_accesskeyid
+          - name: SIGSCI_SECRETACCESSKEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Release.Name }}-secrets-simple
+                key: signalsciences_secretaccesskey
+        securityContext:
+          readOnlyRootFilesystem: true
+        volumeMounts:
+          - name: sigsci-tmp
+            mountPath: /sigsci/tmp
+        lifecycle:
+          preStop:
+            exec:
+              command: [ "/bin/sleep", "30" ]
+        resources:
+          {{- .Values.signalsciences.resources | toYaml | nindent 10 }}
+      {{- end }}
+
       volumes:
         - name: nginx-conf
           configMap:
@@ -85,6 +122,10 @@ spec:
             items:
               - key: .htaccess
                 path: .htaccess
+        {{- end }}
+        {{- if .Values.signalsciences.enabled }}
+        - name: sigsci-tmp
+          emptyDir: { }
         {{- end }}
 ---
 {{- if .Values.autoscaling.enabled }}

--- a/charts/simple/templates/deployment.yaml
+++ b/charts/simple/templates/deployment.yaml
@@ -111,6 +111,10 @@ spec:
                 path: nginx_conf
               - key: simple_conf
                 path: simple_conf
+              {{- if .Values.signalsciences.enabled }}
+              - key: nginx_signalsciences_conf
+                path: nginx_signalsciences_conf
+              {{- end }}
               {{- if .Values.nginx.extraConfig }}
               - key: extraConfig
                 path: extraConfig

--- a/charts/simple/templates/secret.yaml
+++ b/charts/simple/templates/secret.yaml
@@ -7,6 +7,11 @@ metadata:
 type: Opaque
 data:
   {{- if .Values.nginx.basicauth.enabled }}
-  .htaccess: | 
+  .htaccess: |
     {{ printf "%s:{PLAIN}%s" .Values.nginx.basicauth.credentials.username .Values.nginx.basicauth.credentials.password | b64enc }}
+  {{- end }}
+
+  {{- if .Values.signalsciences.enabled }}
+  signalsciences_accesskeyid: {{ .Values.signalsciences.accesskeyid | b64enc | quote }}
+  signalsciences_secretaccesskey: {{ .Values.signalsciences.secretaccesskey | b64enc | quote }}
   {{- end }}

--- a/charts/simple/values.schema.json
+++ b/charts/simple/values.schema.json
@@ -22,7 +22,7 @@
         "vpcNative": { "type": "boolean"}
       }
     },
-    "nginx": { 
+    "nginx": {
       "type": "object",
       "properties": {
         "image": { "type": "string"},
@@ -52,6 +52,12 @@
     },
     "silta-release": {
       "type": "object"
+    },
+    "signalsciences": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
     }
   }
 }

--- a/charts/simple/values.yaml
+++ b/charts/simple/values.yaml
@@ -53,7 +53,7 @@ autoscaling:
 #     hostname: www.example.com
 #   example_no_https:
 #    hostname: insecure.example.com
-#      ssl: 
+#      ssl:
 #        enabled: false
 exposeDomains: {}
 
@@ -122,8 +122,8 @@ nginx:
       cpu: 1m
       memory: 5M
 
-  loglevel: error 
-  
+  loglevel: error
+
   # Set of values to enable and use http basic authentication
   # It is implemented only for very basic protection (like web crawlers)
   basicauth:
@@ -133,9 +133,9 @@ nginx:
     credentials:
       username: silta
       password: demo
-  
+
   # Trust X-Forwarded-For from these hosts for getting external IP
-  realipfrom: 
+  realipfrom:
     gke-internal: 10.0.0.0/8
     gce-health-check-1: 130.211.0.0/22
     gce-health-check-2: 35.191.0.0/16
@@ -160,7 +160,7 @@ nginx:
   #content_security_policy: "upgrade-insecure-requests; default-src https: data: 'unsafe-inline' 'unsafe-eval'; frame-ancestors 'self'; base-uri 'self'; object-src 'self'; connect-src wss: https:"
 
 
-  # Extra configuration block in server context. 
+  # Extra configuration block in server context.
   serverExtraConfig: |
 
   # Extra configuration block in location context.
@@ -168,3 +168,20 @@ nginx:
 
   # Extra configuration to pass to nginx as a file
   extraConfig: |
+
+# Fastly Signal Sciences support
+# https://docs.fastly.com/signalsciences/
+signalsciences:
+  enabled: false
+  accesskeyid: ""
+  secretaccesskey: ""
+  image: signalsciences/sigsci-agent
+  imageTag: 4.40.0
+  # sidecar container resources
+  resources:
+    requests:
+      cpu: 20m
+      memory: 40Mi
+    limits:
+      cpu: 40m
+      memory: 80Mi

--- a/silta/nginx.Dockerfile
+++ b/silta/nginx.Dockerfile
@@ -1,5 +1,4 @@
 # Dockerfile for building nginx.
-#Comment to trigger rebuild
-FROM wunderio/silta-nginx:v0.1
+FROM wunderio/silta-nginx:v0.2
 
 COPY . /app/web


### PR DESCRIPTION
Allows enabling Fastly Signal Sciences WAF agent for inline request reporting and blocking. This PR requires nginx image change (https://github.com/wunderio/silta-images/pull/101).

Tests can be done by  in the feature/fastly-sigsci-demo branch, which is based on this branch but also contains secret with Sigsci test keys and defines custom image (since nginx image changes ain't merged yet).

Source: https://docs.fastly.com/signalsciences/install-guides/kubernetes/kubernetes-agent-module/