### PR TITLE
executor tag, chart version, nginx image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   node16:
     docker:
-      - image: wunderio/silta-cicd:circleci-php8.0-node16-composer2-v0.2
+      - image: wunderio/silta-cicd:circleci-php8.0-node16-composer2-v1
 
 jobs:
   site-test:

--- a/charts/silta-release/Chart.yaml
+++ b/charts/silta-release/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: silta-release
 description: A library chart to provide generic functionality for a silta Helm release.
-version: 0.1.1
+version: 1.0.0

--- a/charts/simple/Chart.lock
+++ b/charts/simple/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: silta-release
   repository: file://../silta-release
   version: 1.0.0
-digest: sha256:5d53d17f5da60923137599215632cfb08880b61100032aca41d3e8eabc2971e7
-generated: "2023-10-02T22:47:34.728171151+03:00"
+digest: sha256:31029ec4b9843923d3d6195b2ad781a0ba06c44d50aaa493e5ca523d2137d15e
+generated: "2023-10-03T09:52:02.967248954+03:00"

--- a/charts/simple/Chart.lock
+++ b/charts/simple/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: silta-release
   repository: file://../silta-release
-  version: 0.1.1
-digest: sha256:63b56b9bedc19c77a6d5bcbd21f6112d73e0aefcbb74eac6ac33ffa2a5f6885a
-generated: "2020-09-10T12:45:50.500536312+03:00"
+  version: 1.0.0
+digest: sha256:5d53d17f5da60923137599215632cfb08880b61100032aca41d3e8eabc2971e7
+generated: "2023-10-02T22:47:34.728171151+03:00"

--- a/charts/simple/Chart.yaml
+++ b/charts/simple/Chart.yaml
@@ -1,7 +1,7 @@
 name: simple
-version: 0.5.0
+version: 1.0.0
 apiVersion: v2
 dependencies:
 - name: silta-release
-  version: 0.1.1
+  version: 1.0.0
   repository: file://../silta-release

--- a/charts/simple/Chart.yaml
+++ b/charts/simple/Chart.yaml
@@ -3,5 +3,5 @@ version: 1.0.0
 apiVersion: v2
 dependencies:
 - name: silta-release
-  version: 1.0.0
+  version: ~1.0
   repository: file://../silta-release

--- a/silta/nginx.Dockerfile
+++ b/silta/nginx.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for building nginx.
-FROM wunderio/silta-nginx:v0.2
+FROM wunderio/silta-nginx:1.17-v1
 
 COPY . /app/web


### PR DESCRIPTION
image version adjustments for Silta 1.0 initiative
Note: don't forget to sync `silta-release` library chart to charts repository!