### PR TITLE
Mapping var, server block for proxy auth header

### DIFF
--- a/charts/simple/templates/configmap.yaml
+++ b/charts/simple/templates/configmap.yaml
@@ -180,11 +180,6 @@ data:
 
         location / {
 
-          {{- if ne .Values.nginx.x_proxy_auth "" }}
-          # Verify if x_proxy_auth value is correct
-          if ( $http_x_proxy_auth != '{{ .Values.nginx.x_proxy_auth }}') { return 403; }
-          {{- end}}
-
             # Custom configuration include
             {{ if .Values.nginx.locationExtraConfig }}
             {{ .Values.nginx.locationExtraConfig | nindent 10 }}

--- a/charts/simple/templates/configmap.yaml
+++ b/charts/simple/templates/configmap.yaml
@@ -107,6 +107,10 @@ data:
 
         # List health checks that need to return status 200 here
         map $http_user_agent $hc_ua { default 0; 'GoogleHC/1.0' 1; 'kube-probe' 1; }
+        {{- if ne .Values.nginx.x_proxy_auth "" }}
+        # Verify if x_proxy_auth value is correct
+        map $http_x_proxy_auth $proxy_auth { default 0; '{{ .Values.nginx.x_proxy_auth }}' 1; }
+        {{- end}}
 
         include conf.d/*.conf;
     }
@@ -144,6 +148,10 @@ data:
 
         # Loadbalancer health checks need to be fed with http 200
         if ($hc_ua) { return 200; }
+        {{- if ne .Values.nginx.x_proxy_auth "" }}
+        # Block request if proxy header is set but does not match required value
+        if ($proxy_auth = 0) { return 403; }
+        {{- end}}
 
         {{- if .Values.nginx.redirects }}
         # Redirects to specified path if map returns anything


### PR DESCRIPTION
Previous approach allowed to bypass header from CDN in some scenarious. 
To not to mess with values and exposed hostnames test environment is created under 
feature/xtestbuild branch
Hostname: 
simple-k8s-staging.fastly.wdr.io

You can wake it up and check direct URL with
`silta ci release wakeup --namespace simple-project-k8s --release-name feature/xtestbuild`