### PR TITLE
Custom clusterIssuer support; Old cert-manager api deprecation

### DIFF
--- a/charts/simple/templates/_helpers.tpl
+++ b/charts/simple/templates/_helpers.tpl
@@ -44,13 +44,7 @@ release: {{ .Release.Name }}
   {{- end }}
 {{- end }}
 
-{{- define "cert-manager.api-version" }}
-{{- if ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
-cert-manager.io/v1
-{{- else }}
-certmanager.k8s.io/v1alpha1
-{{- end }}
-{{- end }}
+
 
 {{- define "ingress.api-version" }}
 {{- if and ( ge $.Capabilities.KubeVersion.Major "1") ( ge $.Capabilities.KubeVersion.Minor "18" ) }}

--- a/charts/simple/templates/certificate.yaml
+++ b/charts/simple/templates/certificate.yaml
@@ -1,57 +1,7 @@
 {{- $context_ingress := .Values.ingress.default }}
 {{- $context_ssl := .Values.ssl }}
 {{- if $context_ingress.tls }}
-{{- if has $context_ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
-apiVersion: {{ include "cert-manager.api-version" . | trim }}
-kind: Certificate
-metadata:
-  name: {{ .Release.Name }}-crt
-  annotations:
-    cert-manager.io/issue-temporary-certificate: "true"
-    acme.cert-manager.io/http01-override-ingress-name: "{{ .Release.Name }}-simple"
-  labels:
-    {{- include "simple.release_labels" . | nindent 4 }}
-spec:
-  secretName: {{ .Release.Name }}-tls
-  dnsNames:
-  - {{ template "simple.domain" . }}
-  issuerRef:
-    name: {{ $context_ssl.issuer }}
-    kind: ClusterIssuer
-{{- if eq ( include "cert-manager.api-version" . | trim ) "certmanager.k8s.io/v1alpha1" }}
-  acme:
-    config:
-      - http01:
-          ingress: {{ .Release.Name }}-simple
-        domains:
-          - {{ template "simple.domain" . }}
-{{- end }}
-  privateKey:
-    rotationPolicy: "Always"
----
-
-{{- else if eq $context_ssl.issuer "selfsigned" }}
-apiVersion: {{ include "cert-manager.api-version" . | trim }}
-kind: Certificate
-metadata:
-  name: {{ .Release.Name }}-crt
-  labels:
-    {{- include "simple.release_labels" . | nindent 4 }}
-spec:
-  secretName: {{ .Release.Name }}-tls
-  duration: 2160h
-  renewBefore: 150h 
-  commonName: {{ template "simple.domain" . }}
-  dnsNames:
-  - {{ template "simple.domain" . }}
-  issuerRef:
-    name: {{ $context_ssl.issuer }}
-    kind: ClusterIssuer
-  privateKey:
-    rotationPolicy: "Always"
----
-
-{{- else if eq $context_ssl.issuer "custom" }}
+{{- if eq $context_ssl.issuer "custom" }}
 {{- if not $context_ssl.existingTLSSecret }}
 apiVersion: v1
 kind: Secret
@@ -66,65 +16,43 @@ data:
   tls.key: {{ $context_ssl.key | b64enc }}
 ---
 {{- end }}
-{{- end }}
-
-# Certificates for exposeDomains 
-
-{{- range $index, $domain := .Values.exposeDomains }}
-{{- $domain := merge $domain $.Values.exposeDomainsDefaults }}
-{{- if $domain.ssl }}
-{{- if $domain.ssl.enabled }}
-{{- if has $domain.ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
-apiVersion: {{ include "cert-manager.api-version" $ | trim }}
+{{- else }}
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ $.Release.Name }}-crt-{{ $index }}
+  name: {{ .Release.Name }}-crt
+  {{- if has $context_ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
   annotations:
     cert-manager.io/issue-temporary-certificate: "true"
-    acme.cert-manager.io/http01-override-ingress-name: "{{ $.Release.Name }}-simple-{{ $domain.ingress }}"
+    acme.cert-manager.io/http01-override-ingress-name: "{{ .Release.Name }}-simple"
+  {{- end }}
   labels:
-    {{- include "simple.release_labels" $ | nindent 4 }}
+    {{- include "simple.release_labels" . | nindent 4 }}
 spec:
-  secretName: {{ $.Release.Name }}-tls-{{ $index }}
-  dnsNames:
-  - {{ $domain.hostname }}
-  issuerRef:
-    name: {{ $domain.ssl.issuer }}
-    kind: ClusterIssuer
-{{- if eq ( include "cert-manager.api-version" $ | trim ) "certmanager.k8s.io/v1alpha1" }}
-  acme:
-    config:
-      - http01:
-          ingress: {{ $.Release.Name }}-simple-{{ $domain.ingress }}
-        domains:
-          - {{ $domain.hostname }}
-{{- end }}
-  privateKey:
-    rotationPolicy: "Always"
----
-
-{{- else if eq $domain.ssl.issuer "selfsigned" }}
-apiVersion: {{ include "cert-manager.api-version" $ | trim }}
-kind: Certificate
-metadata:
-  name: {{ $.Release.Name }}-crt-{{ $index }}
-  labels:
-    {{- include "simple.release_labels" $ | nindent 4 }}
-spec:
-  secretName: {{ $.Release.Name }}-tls-{{ $index }}
+  secretName: {{ .Release.Name }}-tls
+  {{- if eq $context_ssl.issuer "selfsigned" }}
   duration: 2160h
-  renewBefore: 150h 
-  commonName: {{ $domain.hostname }}
+  renewBefore: 150h
+  commonName: {{ template "simple.domain" . }}
+  {{- end }}
   dnsNames:
-  - {{ $domain.hostname }}
+  - {{ template "simple.domain" . }}
   issuerRef:
-    name: {{ $domain.ssl.issuer }}
+    name: {{ $context_ssl.issuer }}
     kind: ClusterIssuer
   privateKey:
     rotationPolicy: "Always"
 ---
+{{- end }}
+{{- end }}
 
-{{- else if eq $domain.ssl.issuer "custom" }}
+# Certificates for exposeDomains
+
+{{- range $index, $domain := .Values.exposeDomains }}
+{{- $domain := mergeOverwrite ($.Values.exposeDomainsDefaults | toYaml | fromYaml) $domain }}
+{{- if $domain.ssl }}
+{{- if $domain.ssl.enabled }}
+{{- if eq $domain.ssl.issuer "custom" }}
 {{- if not $domain.ssl.existingTLSSecret }}
 apiVersion: v1
 kind: Secret
@@ -141,7 +69,33 @@ data:
   tls.key: {{ $domain.ssl.key | default "" | b64enc }}
 ---
 {{- end }}
-{{- end }}
+{{- else }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ $.Release.Name }}-crt-{{ $index }}
+  {{- if has $domain.ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
+  annotations:
+    cert-manager.io/issue-temporary-certificate: "true"
+    acme.cert-manager.io/http01-override-ingress-name: "{{ $.Release.Name }}-simple-{{ $domain.ingress }}"
+  {{- end }}
+  labels:
+    {{- include "simple.release_labels" $ | nindent 4 }}
+spec:
+  secretName: {{ $.Release.Name }}-tls-{{ $index }}
+  {{- if eq $domain.ssl.issuer "selfsigned" }}
+  duration: 2160h
+  renewBefore: 150h
+  commonName: {{ $domain.hostname }}
+  {{- end }}
+  dnsNames:
+  - {{ $domain.hostname }}
+  issuerRef:
+    name: {{ $domain.ssl.issuer }}
+    kind: ClusterIssuer
+  privateKey:
+    rotationPolicy: "Always"
+---
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/simple/templates/ingress.yaml
+++ b/charts/simple/templates/ingress.yaml
@@ -15,11 +15,7 @@ metadata:
     kubernetes.io/ingress.class: {{ $ingress.type | quote }}
     {{- end }}
     {{- if $ingress.tls }}
-    {{- if eq ( include "cert-manager.api-version" . | trim ) "cert-manager.io/v1" }}
     acme.cert-manager.io/http01-edit-in-place: "true"
-    {{- else }}
-    certmanager.k8s.io/acme-http01-edit-in-place: "true"
-    {{- end }}
     {{- if eq $ingress.type "traefik" }}
     traefik.ingress.kubernetes.io/frontend-entry-points: "http,https"
     {{- end }}
@@ -134,7 +130,7 @@ spec:
 
 {{- $letsencrypt_in_use := false }}
 {{- range $index, $domain := $.Values.exposeDomains }}
-{{ $domain := merge $domain $.Values.exposeDomainsDefaults}}
+{{- $domain := mergeOverwrite ($.Values.exposeDomainsDefaults | toYaml | fromYaml) $domain }}
 {{- if eq $domain.ingress $ingress_index }}
 {{- if $domain.ssl }}
 {{- if $domain.ssl.enabled }}
@@ -156,11 +152,7 @@ metadata:
     kubernetes.io/ingress.class: {{ $ingress.type | quote }}
     {{- end }}
     {{- if $ingress.tls }}
-    {{- if eq ( include "cert-manager.api-version" $ | trim ) "cert-manager.io/v1" }}
     acme.cert-manager.io/http01-edit-in-place: "true"
-    {{- else }}
-    certmanager.k8s.io/acme-http01-edit-in-place: "true"
-    {{- end }}
     {{- if eq $ingress.type "traefik" }}
     traefik.ingress.kubernetes.io/frontend-entry-points: "http,https"
     {{- end }}

--- a/charts/simple/tests/certificate_test.yaml
+++ b/charts/simple/tests/certificate_test.yaml
@@ -1,0 +1,309 @@
+suite: Site certificates
+templates:
+  - certificate.yaml
+tests:
+  # --- Main domain ---
+
+  - it: letsencrypt issuer creates a Certificate with ACME annotations
+    template: certificate.yaml
+    set:
+      ssl:
+        issuer: letsencrypt
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Certificate
+      - documentIndex: 0
+        equal:
+          path: apiVersion
+          value: cert-manager.io/v1
+      - documentIndex: 0
+        equal:
+          path: metadata.annotations['cert-manager.io/issue-temporary-certificate']
+          value: "true"
+      - documentIndex: 0
+        exists:
+          path: metadata.annotations['acme.cert-manager.io/http01-override-ingress-name']
+      - documentIndex: 0
+        notExists:
+          path: spec.duration
+      - documentIndex: 0
+        equal:
+          path: spec.issuerRef.name
+          value: letsencrypt
+
+  - it: letsencrypt-staging issuer creates a Certificate with ACME annotations
+    template: certificate.yaml
+    set:
+      ssl:
+        issuer: letsencrypt-staging
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Certificate
+      - documentIndex: 0
+        equal:
+          path: metadata.annotations['cert-manager.io/issue-temporary-certificate']
+          value: "true"
+      - documentIndex: 0
+        equal:
+          path: spec.issuerRef.name
+          value: letsencrypt-staging
+
+  - it: selfsigned issuer creates a Certificate with duration fields and no ACME annotations
+    template: certificate.yaml
+    set:
+      ssl:
+        issuer: selfsigned
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Certificate
+      - documentIndex: 0
+        equal:
+          path: apiVersion
+          value: cert-manager.io/v1
+      - documentIndex: 0
+        equal:
+          path: spec.duration
+          value: 2160h
+      - documentIndex: 0
+        equal:
+          path: spec.renewBefore
+          value: 150h
+      - documentIndex: 0
+        exists:
+          path: spec.commonName
+      - documentIndex: 0
+        notExists:
+          path: metadata.annotations
+      - documentIndex: 0
+        equal:
+          path: spec.issuerRef.name
+          value: selfsigned
+
+  - it: custom issuer creates a Secret when no existingTLSSecret
+    template: certificate.yaml
+    set:
+      ssl:
+        issuer: custom
+        crt: dGVzdA==
+        key: dGVzdA==
+        ca: dGVzdA==
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Secret
+      - documentIndex: 0
+        equal:
+          path: apiVersion
+          value: v1
+      - documentIndex: 0
+        equal:
+          path: type
+          value: kubernetes.io/tls
+
+  - it: custom issuer with existingTLSSecret emits no resources
+    template: certificate.yaml
+    set:
+      ssl:
+        issuer: custom
+        existingTLSSecret: my-existing-secret
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: arbitrary ClusterIssuer creates a plain Certificate without ACME annotations or duration fields
+    template: certificate.yaml
+    set:
+      ssl:
+        issuer: my-cluster-issuer
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Certificate
+      - documentIndex: 0
+        equal:
+          path: apiVersion
+          value: cert-manager.io/v1
+      - documentIndex: 0
+        equal:
+          path: spec.issuerRef.name
+          value: my-cluster-issuer
+      - documentIndex: 0
+        equal:
+          path: spec.issuerRef.kind
+          value: ClusterIssuer
+      - documentIndex: 0
+        notExists:
+          path: metadata.annotations
+      - documentIndex: 0
+        notExists:
+          path: spec.duration
+      - documentIndex: 0
+        notExists:
+          path: spec.commonName
+
+  # --- exposeDomains ---
+
+  - it: exposeDomain with ssl.enabled false creates no certificate
+    template: certificate.yaml
+    set:
+      exposeDomainsDefaults:
+        ingress: default
+        ssl:
+          enabled: true
+          issuer: letsencrypt
+      exposeDomains:
+        foo:
+          hostname: foo.example.com
+          ssl:
+            enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: exposeDomain letsencrypt issuer creates a Certificate with ACME annotations
+    template: certificate.yaml
+    set:
+      ingress:
+        default:
+          tls: false
+      exposeDomains:
+        foo:
+          hostname: foo.example.com
+          ssl:
+            enabled: true
+            issuer: letsencrypt
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Certificate
+      - documentIndex: 0
+        equal:
+          path: apiVersion
+          value: cert-manager.io/v1
+      - documentIndex: 0
+        equal:
+          path: metadata.annotations['cert-manager.io/issue-temporary-certificate']
+          value: "true"
+      - documentIndex: 0
+        exists:
+          path: metadata.annotations['acme.cert-manager.io/http01-override-ingress-name']
+      - documentIndex: 0
+        equal:
+          path: spec.issuerRef.name
+          value: letsencrypt
+      - documentIndex: 0
+        notExists:
+          path: spec.duration
+
+  - it: exposeDomain selfsigned issuer creates a Certificate with duration fields
+    template: certificate.yaml
+    set:
+      ingress:
+        default:
+          tls: false
+      exposeDomains:
+        foo:
+          hostname: foo.example.com
+          ssl:
+            enabled: true
+            issuer: selfsigned
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Certificate
+      - documentIndex: 0
+        equal:
+          path: spec.duration
+          value: 2160h
+      - documentIndex: 0
+        equal:
+          path: spec.renewBefore
+          value: 150h
+      - documentIndex: 0
+        equal:
+          path: spec.commonName
+          value: foo.example.com
+      - documentIndex: 0
+        notExists:
+          path: metadata.annotations
+
+  - it: exposeDomain arbitrary ClusterIssuer creates a plain Certificate
+    template: certificate.yaml
+    set:
+      ingress:
+        default:
+          tls: false
+      exposeDomains:
+        foo:
+          hostname: foo.example.com
+          ssl:
+            enabled: true
+            issuer: my-cluster-issuer
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Certificate
+      - documentIndex: 0
+        equal:
+          path: apiVersion
+          value: cert-manager.io/v1
+      - documentIndex: 0
+        equal:
+          path: spec.issuerRef.name
+          value: my-cluster-issuer
+      - documentIndex: 0
+        equal:
+          path: spec.issuerRef.kind
+          value: ClusterIssuer
+      - documentIndex: 0
+        notExists:
+          path: metadata.annotations
+      - documentIndex: 0
+        notExists:
+          path: spec.duration
+      - documentIndex: 0
+        notExists:
+          path: spec.commonName
+
+  - it: exposeDomain custom issuer creates a Secret
+    template: certificate.yaml
+    set:
+      ingress:
+        default:
+          tls: false
+      exposeDomains:
+        foo:
+          hostname: foo.example.com
+          ssl:
+            enabled: true
+            issuer: custom
+            crt: dGVzdA==
+            key: dGVzdA==
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Secret
+      - documentIndex: 0
+        equal:
+          path: type
+          value: kubernetes.io/tls
+
+  - it: exposeDomain custom issuer with existingTLSSecret creates no Secret
+    template: certificate.yaml
+    set:
+      ingress:
+        default:
+          tls: false
+      exposeDomains:
+        foo:
+          hostname: foo.example.com
+          ssl:
+            enabled: true
+            issuer: custom
+            existingTLSSecret: my-existing-secret
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
- Custom clusterIssuer support, certificate template refactor
- Old cert-manager api depreciation (`certmanager.k8s.io/v1alpha1`, [depreciated in v0.11](https://cert-manager.io/docs/releases/release-notes/release-notes-0.11/).