### PR TITLE
Workaround for traefik double-hypen issue

### DIFF
--- a/charts/simple/templates/ingress-mw.yaml
+++ b/charts/simple/templates/ingress-mw.yaml
@@ -4,7 +4,7 @@
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: {{ $.Release.Name }}-rl
+  name: {{ $.Release.Name | replace "--" "-" }}-rl
   labels:
     {{- include "simple.release_labels" $ | nindent 4 }}
 spec:
@@ -31,7 +31,7 @@ spec:
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: {{ $.Release.Name }}-rl-{{ $ingress_index }}
+  name: {{ $.Release.Name | replace "--" "-" }}-rl-{{ $ingress_index }}
   labels:
     {{- include "simple.release_labels" $ | nindent 4 }}
 spec:

--- a/charts/simple/templates/ingress.yaml
+++ b/charts/simple/templates/ingress.yaml
@@ -72,7 +72,7 @@ metadata:
     {{- end }}
 
     {{- if eq ( include "silta-cluster.traefik3.enabled" $ ) "true" }}
-    traefik.ingress.kubernetes.io/router.middlewares: {{ $.Release.Namespace }}-{{ $.Release.Name }}-rl@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: {{ $.Release.Namespace }}-{{ $.Release.Name | replace "--" "-" }}-rl@kubernetescrd
     {{- end }}
 
     {{- if (index .Values "silta-release").downscaler.enabled }}
@@ -213,7 +213,7 @@ metadata:
     {{- end }}
 
     {{- if eq ( include "silta-cluster.traefik3.enabled" $ ) "true" }}
-    traefik.ingress.kubernetes.io/router.middlewares: {{ $.Release.Namespace }}-{{ $.Release.Name }}-rl@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: {{ $.Release.Namespace }}-{{ $.Release.Name | replace "--" "-" }}-rl@kubernetescrd
     {{- end }}
 
     {{- if (index $.Values "silta-release").downscaler.enabled }}

--- a/charts/simple/tests/ingress_test.yaml
+++ b/charts/simple/tests/ingress_test.yaml
@@ -360,6 +360,23 @@ tests:
           path: metadata.annotations['traefik.ingress.kubernetes.io/router.middlewares']
           value: NAMESPACE-RELEASE-NAME-rl@kubernetescrd
 
+  - it: normalizes double dashes in traefik3 middleware resource name
+    template: ingress-mw.yaml
+    capabilities:
+      apiVersions:
+        - traefik.io/v1alpha1
+    release:
+      name: foo--bar
+    set:
+      ingress:
+        default:
+          type: traefik
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: foo-bar-rl
+
   - it: prevents limit connections above 65536 for default ingress
     template: checks.yaml
     set:


### PR DESCRIPTION
Traefik has issue with middleware names containing double dashes: https://community.traefik.io/t/problem-with-multiple-dash-in-middleware-annotation/18997/3

This is a workaround that replaces double dashes (`--`) in release name to a single dash (`-`).